### PR TITLE
Remove "ALLOW" from "challenge_columns" in the notebooks

### DIFF
--- a/assets/notebooks/notebook-es.ipynb
+++ b/assets/notebooks/notebook-es.ipynb
@@ -374,7 +374,7 @@
     "       'EMPLOYMENT_DURATION', 'INSTALLMENT_PERCENT', 'SEX', 'OTHERS_ON_LOAN',\n",
     "       'CURRENT_RESIDENCE_DURATION', 'PROPERTY', 'AGE', 'INSTALLMENT_PLANS',\n",
     "       'HOUSING', 'EXISTING_CREDITS_COUNT', 'JOB_TYPE', 'DEPENDENTS',\n",
-    "       'TELEPHONE', 'FOREIGN_WORKER', 'ALLOW']\n",
+    "       'TELEPHONE', 'FOREIGN_WORKER']\n",
     "\n",
     "unwanted_columns = list((set(challenge_columns) - set(target)) - set(features)) # Remover todas las colunmas que no son features do nuestro modelo"
    ]

--- a/assets/notebooks/notebook-pt.ipynb
+++ b/assets/notebooks/notebook-pt.ipynb
@@ -375,7 +375,7 @@
     "       'EMPLOYMENT_DURATION', 'INSTALLMENT_PERCENT', 'SEX', 'OTHERS_ON_LOAN',\n",
     "       'CURRENT_RESIDENCE_DURATION', 'PROPERTY', 'AGE', 'INSTALLMENT_PLANS',\n",
     "       'HOUSING', 'EXISTING_CREDITS_COUNT', 'JOB_TYPE', 'DEPENDENTS',\n",
-    "       'TELEPHONE', 'FOREIGN_WORKER', 'ALLOW']\n",
+    "       'TELEPHONE', 'FOREIGN_WORKER']\n",
     "\n",
     "unwanted_columns = list((set(challenge_columns) - set(target)) - set(features)) # Remover todas as colunas que não são features do nosso modelo"
    ]


### PR DESCRIPTION
According to [the instructions](https://github.com/maratonadev/desafio-1-2021/blob/0b7facda9e2c4d2bd7c71b885fcedc3f63933634/doc/instructions/pt.md#53-desenvolvimento), the model will not receive the "ALLOW" column, which is the target variable we want to predict. Indeed, if that was available to the model, it could simply output its values and no other features would be necessary.